### PR TITLE
Fix warnings for upcoming PHP 8.1

### DIFF
--- a/src/ImageGenerator.php
+++ b/src/ImageGenerator.php
@@ -111,8 +111,8 @@ class ImageGenerator
                 $imageResource,
                 $size,
                 0,
-                $x,
-                $y,
+                (int) $x,
+                (int) $y,
                 $allocatedFgColor,
                 $font,
                 $text


### PR DESCRIPTION
I got the following Notice while using the last image-generator version:
```
NOTICE: PHP message: PHP Deprecated:  Implicit conversion from float 219.5 to int loses precision in /var/www/html/vendor/nicoverbruggen/image-generator/src/ImageGenerator.php on line 111
```
I have seen that similar fixes have already been applied to other parts of the codebase, but these two lines were missing.

To address this, I have explicitly cast the floating-point values to integers where `$x` and `$y` coordinates are calculated. This change aligns with the fixes made elsewhere in the code by you and ensures compatibility with PHP 8's type enforcement, preventing the deprecation notice related to precision loss during the float-to-int conversion. This should maintain the functionality while adhering to PHP 8's stricter type requirements.

I hope you can add this fix into the main codebase. This modification has resolved the issue in my environment, and I believe it would be beneficial for other users as well. Looking forward to seeing this enhancement in the next update of the image-generator. :)